### PR TITLE
Update Node to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
     description: 'Is the task complete'
     required: false
 branding:
-  icon: 'chevron-right'  
+  icon: 'chevron-right'
   color: 'gray-dark'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
## Background

Per this [thread](https://panther-labs.slack.com/archives/C026QGU2UG4/p1677805423137409), I noticed the deprecation notice for Node 12 and this PR is for updating this GitHub Action to use Node 16. I don't believe this fixes the original issue in the thread.

## Changes
- Remove trailing space in line 39
- Update Node to 16

## Testing

Do I need to bump action version?

