### PR TITLE
refactor: find task regex

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -49,7 +49,7 @@ async function addComment(client, taskId, commentId, text, isPinned) {
 }
 
 function findTasksFromPrBody(body, triggerPhrase = '') {
-  const REGEX_STRING = `(${triggerPhrase})(?:\\s*)https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+)`;
+  const REGEX_STRING = `(${triggerPhrase})(:?\\s*)https:\\/\\/app.asana.com\\/(\\d+)\\/(?<project>\\d+)\\/(?<task>\\d+)`;
   const REGEX = new RegExp(REGEX_STRING,'g')
 
   console.info('looking in body', body, '\nregex', REGEX_STRING);


### PR DESCRIPTION
## Background

I suspect this was a typo! the `:` and `?` were transposed

## Changes

optional character not capture group

## Testing
<img width="817" alt="Screenshot 2023-04-24 at 4 18 17 PM" src="https://user-images.githubusercontent.com/43256356/234135874-017ba305-24e2-432f-a0ed-5f3712225c2e.png">

<img width="789" alt="Screenshot 2023-04-24 at 4 32 04 PM" src="https://user-images.githubusercontent.com/43256356/234137589-47004b2c-57d1-42c0-8aae-ce711444c328.png">
<img width="819" alt="Screenshot 2023-04-24 at 4 32 10 PM" src="https://user-images.githubusercontent.com/43256356/234137596-2ce55eff-a9d7-44ab-b53f-e289ce6101e5.png">
<img width="808" alt="Screenshot 2023-04-24 at 4 32 16 PM" src="https://user-images.githubusercontent.com/43256356/234137600-7276c7fb-5997-43e0-bf5c-00c84317ca7f.png">

