### PR TITLE
Update node and actions

### DIFF
--- a/.github/workflows/asana_demo.yml
+++ b/.github/workflows/asana_demo.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout Repo
      
       - uses: ./
@@ -40,7 +40,7 @@ jobs:
     if: ${{ github.event.pull_request.state == 'closed' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout Repo
         
       - uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: set environment variables
         run: echo "SHORT_SHA=$(git rev-parse --short=7 ${{ github.sha }})" >> $GITHUB_ENV
       - name: Create Release

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ branding:
   icon: 'chevron-right'  
   color: 'gray-dark'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
## Background

Node12 is long since EOL so we need to upgrade to 20.

We can also upgrade the `checkout` action from version 2 to version 4.

## Changes

- Change version in `runs` to node20
- Change version of `checkout` action to 4

## Testing

- YOLO
